### PR TITLE
fix: typeorm timezone asia 설정 #14

### DIFF
--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -25,6 +25,7 @@ import { OrderModule } from './order/order.module';
         database: configService.get('DATABASE_NAME'),
         entities: ['dist/**/*.entity.js'],
         synchronize: true,
+        timezone: 'Asia/Seoul',
       }),
     }),
     MenuModule,


### PR DESCRIPTION
- 전 커밋에서 누락.

## 설명
- 전 커밋 누락된 변경 추가 
- timezone : asia/seoul로 변경 

## 관련이슈
- #14 
